### PR TITLE
fix iOS build, remove deprecated API

### DIFF
--- a/Sources/Syntax/Cache/OrderedSet.swift
+++ b/Sources/Syntax/Cache/OrderedSet.swift
@@ -100,8 +100,6 @@ func == <T>(lhs: OrderedSet<T>, rhs: OrderedSet<T>) -> Bool {
     return lhs.contents == rhs.contents
 }
 
-extension OrderedSet: Hashable where Element: Hashable { }
-
 extension OrderedSet {
 
     static func + (lhs: OrderedSet<Element>, rhs: Element) -> OrderedSet<Element> {

--- a/Sources/Syntax/FunctionBuilder/EitherParserBuilder.swift
+++ b/Sources/Syntax/FunctionBuilder/EitherParserBuilder.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-@_functionBuilder
+@resultBuilder
 public struct EitherParserBuilder {
     public static func buildExpression<C0: Parser>(_ c0: C0) -> AnyParser<C0.Output> {
         return c0.eraseToAnyParser()

--- a/Sources/Syntax/FunctionBuilder/ParserBuilder.swift
+++ b/Sources/Syntax/FunctionBuilder/ParserBuilder.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@_functionBuilder
+@resultBuilder
 public struct ParserBuilder {
 
     public static func buildExpression<P: Parser>(_ parser: P) -> PartialEmptyParserResult where P.Output == Void {

--- a/Sources/Syntax/Parser.swift
+++ b/Sources/Syntax/Parser.swift
@@ -112,7 +112,7 @@ extension Parser {
         }
 
         let storage: MemoizationStorage
-        if #available(OSX 10.15, *) {
+        if #available(OSX 10.15, iOS 13, *) {
             storage = cache.storage(for: text)
         } else {
             storage = MemoizationStorage()

--- a/Sources/Syntax/Parser.swift
+++ b/Sources/Syntax/Parser.swift
@@ -112,7 +112,8 @@ extension Parser {
         }
 
         let storage: MemoizationStorage
-        if #available(OSX 10.15, iOS 13, *) {
+        
+        if #available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *) {
             storage = cache.storage(for: text)
         } else {
             storage = MemoizationStorage()


### PR DESCRIPTION
I saw that the tests were failing on iOS, so I made the changes necessary to make the tests pass on iOS and iPadOS in addition to macOS.